### PR TITLE
Update runtime to 49

### DIFF
--- a/com.github.ryonakano.konbucase.yml
+++ b/com.github.ryonakano.konbucase.yml
@@ -1,6 +1,6 @@
 id: com.github.ryonakano.konbucase
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: com.github.ryonakano.konbucase
 finish-args:
@@ -8,20 +8,11 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/vala
 modules:
-  - name: blueprint-compiler
-    buildsystem: meson
-    cleanup:
-      - '*'
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        tag: v0.18.0
-        commit: 07c9c9df9cd1b6b4454ecba21ee58211e9144a4b
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
-
   - name: chcase
     buildsystem: meson
     sources:


### PR DESCRIPTION
- Update runtime to 49
- Drop the blueprint compiler, which is  already provided by the runtime
- Add cleanup commands to reduce the Flatpak size